### PR TITLE
fix borrowNFT method

### DIFF
--- a/contracts/Ballerz.cdc
+++ b/contracts/Ballerz.cdc
@@ -730,8 +730,8 @@ access(all) contract Gaia: ViewResolver, NonFungibleToken {
         // Gets a reference to an NFT in the collection
         // so that the caller can read its metadata and call its methods
         //
-        access(all) view fun borrowNFT(_ id: UInt64): &{NonFungibleToken.NFT} {
-            return (&self.ownedNFTs[id])!
+        access(all) view fun borrowNFT(_ id: UInt64): &{NonFungibleToken.NFT}? {
+            return &self.ownedNFTs[id]
         }
 
         // borrowGaiaNFT


### PR DESCRIPTION
We may have a slight typo in the Ballerz contract that is causing a cadence bug. As a result, the `borrowNFT` method always crashes when used. You can reproduce the problem by running the following script (You may have to change the inputs if ownership of the current sample changes)

[Script](https://run.flowty.io?code=aW1wb3J0IE5vbkZ1bmdpYmxlVG9rZW4gZnJvbSAweDFkN2U1N2FhNTU4MTc0NDgKaW1wb3J0IFZpZXdSZXNvbHZlciBmcm9tIDB4MWQ3ZTU3YWE1NTgxNzQ0OAppbXBvcnQgTWV0YWRhdGFWaWV3cyBmcm9tIDB4MWQ3ZTU3YWE1NTgxNzQ0OAppbXBvcnQgQWRkcmVzc1V0aWxzIGZyb20gMHhhMzQwZGMwYTRlYzgyOGFiCgphY2Nlc3MoYWxsKSBmdW4gbWFpbihhZGRyZXNzOiBBZGRyZXNzLCBuZnRJZDogVUludDY0LCB0eXBlSWRlbnRpZmllcjogU3RyaW5nKTogQm9vbCB7CiAgICAvLyBzZWUgbm90ZSBpbiBBY2NvdW50U2VydmljZS50cyBhYm91dCB1c2luZyBORlQgcmVzb3VyY2UgbmFtZQogICAgbGV0IG5mdFR5cGUgPSBDb21wb3NpdGVUeXBlKHR5cGVJZGVudGlmaWVyKSA%2FPyBwYW5pYygiSW52YWxpZCB0eXBlIGlkZW50aWZpZXIiKQogICAgbGV0IG5mdEFkZHJlc3MgPSBBZGRyZXNzVXRpbHMucGFyc2VBZGRyZXNzKG5mdFR5cGUpIQogICAgbGV0IG5mdENvbnRyYWN0TmFtZSA9IHR5cGVJZGVudGlmaWVyLnNwbGl0KHNlcGFyYXRvcjogIi4iKVsyXQogICAgbGV0IG5mdENvbnRyYWN0ID0gZ2V0QWNjb3VudChuZnRBZGRyZXNzKS5jb250cmFjdHMuYm9ycm93PCZ7Vmlld1Jlc29sdmVyfT4obmFtZTogbmZ0Q29udHJhY3ROYW1lKQogICAgICAgID8%2FIHBhbmljKCJjb250cmFjdCBub3QgZm91bmQgb3IgZG9lcyBub3QgaW1wbGVtZW50IFZpZXdSZXNvbHZlciBpbnRlcmZhY2UiKQoKICAgIGxldCBtZCA9IG5mdENvbnRyYWN0LnJlc29sdmVDb250cmFjdFZpZXcocmVzb3VyY2VUeXBlOiBuZnRUeXBlLCB2aWV3VHlwZTogVHlwZTxNZXRhZGF0YVZpZXdzLk5GVENvbGxlY3Rpb25EYXRhPigpKQogICAgICAgID8%2FIHBhbmljKCJORlRDb2xsZWN0aW9uRGF0YSBtZXRhZGF0YSB2aWV3IG5vdCBmb3VuZCIpCgogICAgbGV0IGNvbGxlY3Rpb25EYXRhID0gbWQgYXMhIE1ldGFkYXRhVmlld3MuTkZUQ29sbGVjdGlvbkRhdGEKCiAgICBsZXQgY29sbGVjdGlvbiA9IGdldEF1dGhBY2NvdW50PGF1dGgoU3RvcmFnZSkgJkFjY291bnQ%2BKGFkZHJlc3MpLnN0b3JhZ2UuYm9ycm93PCZ7Tm9uRnVuZ2libGVUb2tlbi5Db2xsZWN0aW9uUHVibGljfT4oZnJvbTogY29sbGVjdGlvbkRhdGEuc3RvcmFnZVBhdGgpCiAgICBpZiBjb2xsZWN0aW9uID09IG5pbCB7CiAgICAJbG9nKCJDb2xsZWN0aW9uIG5vdCBmb3VuZCIpCiAgICAgIHJldHVybiBmYWxzZQogICAgfQoKICAgIGxldCBuZnQgPSBjb2xsZWN0aW9uIS5ib3Jyb3dORlQobmZ0SWQpCgogICAgcmV0dXJuIG5mdCAhPSBuaWwgJiYgbmZ0IS5nZXRUeXBlKCkgPT0gbmZ0VHlwZQp9ICA%3D&network=mainnet&args=eyJ0eXBlSWRlbnRpZmllciI6IkEuOGIxNDgxODNjMjhmZjg4Zi5HYWlhLk5GVCIsIm5mdElkIjo4NjgsImFkZHJlc3MiOiIweDlmODZhYjRhODM0OTA0ZTcifQ%3D%3D)